### PR TITLE
Flash bootloader to both slots

### DIFF
--- a/src/factory.ts
+++ b/src/factory.ts
@@ -119,7 +119,24 @@ async function tryFlashImages(
         let pattern = new RegExp(`${imageName}(?:-.+)?\\.img$`);
         let entry = entries.find((entry) => entry.filename.match(pattern));
         if (entry !== undefined) {
-            await flashEntryBlob(device, entry, onProgress, imageName);
+            if (imageName == "bootloader") {
+                let current_slot = await device.getVariable("current-slot");
+                if (current_slot == "a") {
+                    await flashEntryBlob(device, entry, onProgress, (imageName + "_b"));
+                    await device.runCommand("set_active:b");
+                } else if (current_slot == "b") {
+                    await flashEntryBlob(device, entry, onProgress, (imageName + "_a"));
+                    await device.runCommand("set_active:a");
+                } else {
+                    throw new FastbootError(
+                        "FAIL",
+                        `Invalid slot given by bootloader.`
+                    );
+                }
+            }
+            else {
+                await flashEntryBlob(device, entry, onProgress, imageName);
+            }
         }
     }
 }
@@ -214,7 +231,16 @@ export async function flashZip(
         await device.reboot("bootloader", true, onReconnect);
     }
 
-    // 1. Bootloader pack
+    // 1. Bootloader pack (repeated for slot A and B)
+    await tryFlashImages(device, entries, onProgress, ["bootloader"]);
+    await common.runWithTimedProgress(
+        onProgress,
+        "reboot",
+        "device",
+        BOOTLOADER_REBOOT_TIME,
+        tryReboot(device, "bootloader", onReconnect)
+    );
+
     await tryFlashImages(device, entries, onProgress, ["bootloader"]);
     await common.runWithTimedProgress(
         onProgress,


### PR DESCRIPTION
Following Google blowing an efuse as part of loading the Android 13 bootloade and then successfully booting the Android OS, flash the other slot, change to other slot, reboot, and flash the other slot, change to other slot, reboot. By having bootloader on both slots, an A/B rollback should not be able to brick a device as would otherwise happen on 6th generation Pixels.