### PR TITLE
use Blob instead of ArrayBuffer for raw to sparse conversion

### DIFF
--- a/src/fastboot.ts
+++ b/src/fastboot.ts
@@ -559,12 +559,7 @@ export class FastbootDevice {
         // Convert image to sparse (for splitting) if it exceeds the size limit
         if (blob.size > maxDlSize && !isSparse) {
             common.logDebug(`${partition} image is raw, converting to sparse`);
-
-            // Assume that non-sparse images will always be small enough to convert in RAM.
-            // The buffer is converted to a Blob for compatibility with the existing flashing code.
-            let rawData = await common.readBlobAsBuffer(blob);
-            let sparse = Sparse.fromRaw(rawData);
-            blob = new Blob([sparse]);
+            blob = await Sparse.fromRaw(blob);
         }
 
         common.logDebug(


### PR DESCRIPTION
Raw images can be quite large, and it might not be possible to convert the images in RAM, on low memory devices, as raw to sparse conversion can consume memory more than twice the size of the image being converted. This commit also reduces fastboot.js peak memory usage during flashing.