### PR TITLE
factory-optimized: adjust FlashScript parser to changed entry paths

### DIFF
--- a/src/factory.ts
+++ b/src/factory.ts
@@ -213,7 +213,7 @@ export async function flashZip(
     let reader = new ZipReader(new BlobReader(blob));
     let entries = await reader.getEntries();
 
-    if (entries.find((e) => e.filename === "script.txt") !== undefined) {
+    if (entries.find((e) => e.filename.endsWith("/script.txt")) !== undefined) {
         await flashOptimizedFactoryZip(device, entries, wipe, onReconnect, onProgress);
         return;
     }


### PR DESCRIPTION
Zip entries are now contained in an outer directory.